### PR TITLE
Circumvent Undefined property warning resolves kaltura#405.

### DIFF
--- a/local/kaltura/locallib.php
+++ b/local/kaltura/locallib.php
@@ -792,7 +792,7 @@ function local_kaltura_get_config() {
         $configsettings->kaf_uri = 'http://'.$configsettings->kaf_uri;
     }
 
-    if (!empty($configsettings->kaf_uri) && $configsettings->lti_version == LTI_VERSION_1P3) {
+    if (isset($configsettings->lti_version) && (!empty($configsettings->kaf_uri) && $configsettings->lti_version == LTI_VERSION_1P3)) {
         $configsettings->public_keyset_url = $configsettings->kaf_uri . '/hosted/index/lti-advantage-key-set';
         $configsettings->launch_url = $configsettings->kaf_uri . '/hosted/index/oidc-init';
         $configsettings->redirection_uris = $configsettings->kaf_uri . '/hosted/index/oauth2-launch';


### PR DESCRIPTION
**Description:** This resolves https://github.com/kaltura/moodle_plugin/issues/405 (see for more information) allowing plugin install to occur without warnings or errors

**Problem**
```
== Setting new default values ==

Warning: Undefined property: stdClass::$lti_version in /var/www/site/local/kaltura/locallib.php on line 795
```
Code that is causing the error
```php
795if (!empty($configsettings->kaf_uri) && $configsettings->lti_version == LTI_VERSION_1P3) {
796    if (isset($configsettings->lti_version) && (!empty($configsettings->kaf_uri) && $configsettings->lti_version == LTI_VERSION_1P3)) {
797        $configsettings->public_keyset_url = $configsettings->kaf_uri . '/hosted/index/lti-advantage-key-set';
798        $configsettings->public_keyset_url = $configsettings->kaf_uri . '/hosted/index/lti-advantage-key-set';
799        $configsettings->launch_url = $configsettings->kaf_uri . '/hosted/index/oidc-init';
800        $configsettings->launch_url = $configsettings->kaf_uri . '/hosted/index/oidc-init';
801        $configsettings->redirection_uris = $configsettings->kaf_uri . '/hosted/index/oauth2-launch';
802        $configsettings->redirection_uris = $configsettings->kaf_uri . '/hosted/index/oauth2-launch';
803    }
```

**Solution**

Check that $configsettings->lti_version is set first
```php
if (isset($configsettings->lti_version) && (!empty($configsettings->kaf_uri) && $configsettings->lti_version == LTI_VERSION_1P3)) {
    ...
}
```